### PR TITLE
Implement block to call block

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ client = MT::DataAPI::Client.new(
   base_url: 'http://localhost/mt/mt-data-api.cgi',
   client_id: 'mt-ruby'
 )
+
+# without block
 json = client.call(:list_entries, site_id: 1)
+
+# with block
+client.call(:list_sites) do |res|
+  json = res
+end
 ```
 
 ## Development

--- a/lib/mt/data_api/client.rb
+++ b/lib/mt/data_api/client.rb
@@ -22,7 +22,7 @@ module MT
         res = endpoint.call(@access_token, args)
         @access_token = res['accessToken'] if id == 'authenticate'
         @endpoint_manager.endpoints = res['items'] if id == 'list_endpoints'
-        res
+        block_given? ? yield(res) : res
       end
 
       def endpoints

--- a/spec/lib/mt/data_api/client_spec.rb
+++ b/spec/lib/mt/data_api/client_spec.rb
@@ -104,6 +104,21 @@ describe MT::DataAPI::Client do
             expect(a_request(:get, url)).to have_been_made.times(1)
           end
         end
+
+        context 'with block' do
+          before do
+            @client = described_class.new(opts_with_endpoints)
+            @client.call(endpoints[0]['id']) do |res|
+              @res = res
+            end
+          end
+
+          it_behaves_like :list_endpoints
+
+          it 'calls http requests 1 time' do
+            expect(a_request(:get, url)).to have_been_made.times(1)
+          end
+        end
       end
 
       context 'when authenticate' do


### PR DESCRIPTION
example:

```ruby
client = MT::DataAPI::Client.new(
  base_url: 'http://localhost/mt/mt-data-api.cgi',
  client_id: 'mt-ruby'
)

client.call(:list_entries, site_id: 1) do |res|
  json = res
end
```