### PR TITLE
Fix failed test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'bundler/gem_tasks'
 
-default = [:spec, :rubocop, :bundle_outdated]
+default = [:spec, :rubocop]
 task default: default
 
 desc 'circleci'

--- a/mt-data_api-client.gemspec
+++ b/mt-data_api-client.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'rake', '~> 11.2'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'rubocop', '~> 0.42'
+  spec.add_development_dependency 'rubocop', '0.42.0'
   spec.add_development_dependency 'webmock', '~> 2.1'
 end


### PR DESCRIPTION
* Remove "bundle outdated" because it is wrong to keep gems latest
* Use rubocop@0.42.0 temporarily because new version of rubocop may have changed its rules
