### PR TITLE
Enable to send file to upload_asset endpoint

### DIFF
--- a/spec/lib/mt/data_api/client/api_request_spec.rb
+++ b/spec/lib/mt/data_api/client/api_request_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper.rb'
 
+require 'tempfile'
 require 'webmock/rspec'
 
 require 'mt/data_api/client/api_request'
@@ -77,6 +78,29 @@ describe MT::DataAPI::Client::APIRequest do
 
         it_behaves_like :ok_response
       end
+
+      context 'with file' do
+        before do
+          url = "#{api_url}/assets/upload"
+          stub_request(:post, url)
+            .with(headers: { 'Content-Type': 'multipart/form-data' })
+            .to_return(body: '{}')
+        end
+
+        let(:endpoint) do
+          hash = {
+            id: 'upload_asset',
+            route: '/assets/upload',
+            version: 2,
+            verb: 'POST',
+          }
+          MT::DataAPI::Client::Endpoint.new(hash)
+        end
+        let(:access_token) { 'token' }
+        let(:args) { { site_id: 1, file: Tempfile.create('foo') } }
+
+        it_behaves_like :ok_response
+      end
     end
 
     context 'when PUT method' do
@@ -109,6 +133,29 @@ describe MT::DataAPI::Client::APIRequest do
         end
         let(:access_token) { nil }
         let(:args) { { name: 'sample', id: 9 } }
+
+        it_behaves_like :ok_response
+      end
+
+      context 'with file' do
+        before do
+          url = "#{api_url}/put_file"
+          stub_request(:put, url)
+            .with(headers: { 'Content-Type': 'multipart/form-data' })
+            .to_return(body: '{}')
+        end
+
+        let(:endpoint) do
+          hash = {
+            id: 'put_file',
+            route: '/put_file',
+            version: 1,
+            verb: 'PUT',
+          }
+          MT::DataAPI::Client::Endpoint.new(hash)
+        end
+        let(:access_token) { 'token' }
+        let(:args) { { put_file: Tempfile.create('foo') } }
 
         it_behaves_like :ok_response
       end

--- a/spec/lib/mt/data_api/client/api_request_spec.rb
+++ b/spec/lib/mt/data_api/client/api_request_spec.rb
@@ -83,7 +83,7 @@ describe MT::DataAPI::Client::APIRequest do
         before do
           url = "#{api_url}/assets/upload"
           stub_request(:post, url)
-            .with(headers: { 'Content-Type': 'multipart/form-data' })
+            .with(headers: { 'Content-Type' => 'multipart/form-data' })
             .to_return(body: '{}')
         end
 
@@ -141,7 +141,7 @@ describe MT::DataAPI::Client::APIRequest do
         before do
           url = "#{api_url}/put_file"
           stub_request(:put, url)
-            .with(headers: { 'Content-Type': 'multipart/form-data' })
+            .with(headers: { 'Content-Type' => 'multipart/form-data' })
             .to_return(body: '{}')
         end
 

--- a/spec/lib/mt/data_api/client/api_request_spec.rb
+++ b/spec/lib/mt/data_api/client/api_request_spec.rb
@@ -97,7 +97,11 @@ describe MT::DataAPI::Client::APIRequest do
           MT::DataAPI::Client::Endpoint.new(hash)
         end
         let(:access_token) { 'token' }
-        let(:args) { { site_id: 1, file: Tempfile.create('foo') } }
+        let(:args) {
+          temp = Tempfile.new('foo')
+          file = File.open(temp.path)
+          { site_id: 1, file: file }
+        }
 
         it_behaves_like :ok_response
       end
@@ -155,7 +159,11 @@ describe MT::DataAPI::Client::APIRequest do
           MT::DataAPI::Client::Endpoint.new(hash)
         end
         let(:access_token) { 'token' }
-        let(:args) { { put_file: Tempfile.create('foo') } }
+        let(:args) {
+          temp = Tempfile.new('foo')
+          file = File.open(temp.path)
+          { put_file: file }
+        }
 
         it_behaves_like :ok_response
       end


### PR DESCRIPTION
Set 'multipart/form-data' to 'Content-Type' header when File object is set in endpoint arguments